### PR TITLE
@craigspaeth cc @broskoski: Use a custom error type and newrelic.shutdown

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,10 @@ module.exports = function(req, res, next) {
 process.on('uncaughtException', function(err) {
   console.error("Uncaught Exception", err.stack);
   newrelic.noticeError(err, { crash: true });
-  newrelic.agent.harvest(function() {
-    console.log("Sent to NewRelic, exiting process.");
+  newrelic.shutdown({ collectPendingData: true }, function(err) {
+    err
+      ? console.log("Failed to send to NewRelic.", err)
+      : console.log("Sent to NewRelic, exiting process.");
     process.exit(1);
   });
 });

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ var UncaughtError = function UncaughtError(err) {
   this.message = err.message || err.toString();
   this.stack = err.stack;
 };
+UncaughtError.prototype = Error.prototype;
 
 process.on('uncaughtException', function(e) {
   var err = new UncaughtError(e);

--- a/index.js
+++ b/index.js
@@ -9,7 +9,14 @@ module.exports = function(req, res, next) {
   next();
 }
 
-process.on('uncaughtException', function(err) {
+var UncaughtError = function UncaughtError(err) {
+  this.name = 'UncaughtError';
+  this.message = err.message || err.toString();
+  this.stack = err.stack;
+};
+
+process.on('uncaughtException', function(e) {
+  var err = new UncaughtError(e);
   console.error("Uncaught Exception", err.stack);
   newrelic.noticeError(err, { crash: true });
   newrelic.shutdown({ collectPendingData: true }, function(err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artsy-newrelic",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Plug-and-play NewRelic module wrapper configured for Artsy Node apps.",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
I think it's hard to find uncaught exceptions in Force because we end up sometimes crashing the process before we send the report to NR.

The documentation on this stuff could be better... I had to log the arguments from `newrelic.agent.harvest()` to discover it passes it's own error object that was reporting "not connected to new relic" and after digging through their Github README I discovered `newrelic.shutdown({ collectPendingData: true }` which appears to be the better way to do it now.

Also, while using the custom parameter `{ crash: true }` seems to sometimes work—you can't actually filter down on custom parameters in the NR UI, so it's kinda useless. All it does is add this table to the right of the error view:

![image](https://cloud.githubusercontent.com/assets/555859/16061620/e4c95676-325b-11e6-809c-611bb721ba57.png)

So instead I created a custom `UncaughtError` type that _can_ be filtered on in NR...

![image](https://cloud.githubusercontent.com/assets/555859/16061632/ffeb34ba-325b-11e6-8201-744edc892381.png)

Hopefully this will make it easier to find uncaught exception in our Node apps using NR.
